### PR TITLE
make cldr a shallow clone

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,7 @@
 [submodule "src/third-party/cldr"]
 	path = src/third-party/cldr
 	url = https://github.com/unicode-org/cldr.git
+	shallow = true
 [submodule "data/voices/victoria"]
 	path = data/voices/victoria
 	url = https://github.com/rhvoice/victoria-ru


### PR DESCRIPTION
this really reduces the time it takes to clone the repository, besides
in this case, we do not need the complete history of the cldr repository.
