### PR TITLE
Revert "make cldr a shallow clone"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,6 @@
 [submodule "src/third-party/cldr"]
 	path = src/third-party/cldr
 	url = https://github.com/unicode-org/cldr.git
-	shallow = true
 [submodule "data/voices/victoria"]
 	path = data/voices/victoria
 	url = https://github.com/rhvoice/victoria-ru


### PR DESCRIPTION
it turned out that if we track the tag, then the repository is cloned with a depth of 1 and then, when searching for a ref, it is cloned completely.

Reverts RHVoice/RHVoice#317