### PR TITLE
Core: set the version number to the next release version

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -27,7 +27,7 @@ if sys.platform=="win32":
         import _winreg as winreg
 
 def get_version(is_release):
-    next_version="1.3.18"
+    next_version="1.4.0"
     return next_version
 
 def passthru(env, cmd, unique=False):

--- a/src/core/SConscript
+++ b/src/core/SConscript
@@ -33,7 +33,7 @@ extern_libs_dir=Dir("#external").Dir("libs")
 local_env=env.Clone()
 if env["enable_sonic"]:
 		local_env.Append(CPPPATH=[extern_libs_dir.Dir("sonic")])
-local_env["libversion"]="4.0.0"
+local_env["libversion"]="5.0.0"
 local_env["liblevel"]=1
 
 coreConfig = {


### PR DESCRIPTION
Also update the shared library version.

The rest of the updates before the release shouldn't touch the core itself, unless something important really needs fixing.
