### PR TITLE
Core: fix the Macedonian language identifier value

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -27,7 +27,7 @@ if sys.platform=="win32":
         import _winreg as winreg
 
 def get_version(is_release):
-    next_version="1.4.0"
+    next_version="1.4.1"
     return next_version
 
 def passthru(env, cmd, unique=False):

--- a/data/SConscript
+++ b/data/SConscript
@@ -12,7 +12,7 @@ import RHVoiceInfoParser
 Import("env")
 local_env=env.Clone()
 
-nvda_addon_build_number=".8"
+nvda_addon_build_number=".9"
 
 def list_files(dir):
 	files=[]
@@ -33,7 +33,7 @@ lang_files=dict()
 lang_ver_ids=dict()
 
 msi_build_number=".2"
-exe_build_number=".12"
+exe_build_number=".13"
 
 for dir_name in ["languages","voices"]:
 	type=dir_name[:-1]

--- a/src/include/core/macedonian.hpp
+++ b/src/include/core/macedonian.hpp
@@ -31,7 +31,7 @@ namespace RHVoice
     #ifdef WIN32
     unsigned short get_id() const
     {
-      return 1058;
+      return 1071;
     }
     #endif
 


### PR DESCRIPTION
This is an important emergency fix. Moving to 1.4.1 for compatibility reasons.
