### PR TITLE
Fixes in CMake scripts related to libsonic.

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -41,7 +41,7 @@ set(package_name "RHVoice_core")
 
 set(VERSION "${RHVOICE_VERSION}")
 
-if(ENABLE_MAGE)
+if(ENABLE_SONIC)
 	list(APPEND libs2link "sonic")
 endif()
 if(ENABLE_MAGE)

--- a/src/third-party/sonic/CMakeLists.txt
+++ b/src/third-party/sonic/CMakeLists.txt
@@ -13,13 +13,14 @@
 
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-find_package(Sonic REQUIRED)
+find_package(Sonic)
 set(SONIC_DIR "${CMAKE_SOURCE_DIR}/external/libs/sonic")
 
 if(SONIC_FOUND)
 	message(STATUS "Sonic found, using from the distribution packages. Set Sonic_FORCE_COMPILATION if you want to use it from a submodule.")
 	set(Sonic_FORCE_COMPILATION OFF)
 else()
+	message(STATUS "Sonic NOT found, building an own one.")
 	set(Sonic_FORCE_COMPILATION ON)
 endif()
 


### PR DESCRIPTION
Fixed an error in CMake script adding sonic depending on ENABLE_MAGE
Made pkg-config sonic non-mandatory.
Added a message for the case sonic is not found in pkg-config and is built by us.