### PR TITLE
Disconnected conditional building of speech_dispatcher module and DBus servers and clients from platform.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,12 @@
-set(BUILD_CLIENT ON CACHE BOOL "Build standalone RHVoice-client application")
+pkg_check_modules(DBUS dbus)
+pkg_check_modules(LIBGIOMM giomm-2.4)
+pkg_check_modules(SPEECHD speech-dispatcher)
+
+set(BUILD_CLIENT "${DBUS_FOUND}" CACHE BOOL "Build standalone RHVoice-client application")
 set(BUILD_UTILS ON CACHE BOOL "Build some useful utils")
 set(BUILD_TESTS ON CACHE BOOL "Build test applications")
-set(BUILD_SERVICE ON CACHE BOOL "Build RHVoice server application")
-set(BUILD_SPEECHDISPATCHER_MODULE ON CACHE BOOL "Build SpeechDispatcher module")
+set(BUILD_SERVICE "${LIBGIOMM_FOUND}" CACHE BOOL "Build RHVoice server application")
+set(BUILD_SPEECHDISPATCHER_MODULE "${SPEECHD_FOUND}" CACHE BOOL "Build SpeechDispatcher module")
 
 set(INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
 configure_file("${INCLUDE_DIR}/core/config.h.in" "${INCLUDE_DIR}/core/config.h")
@@ -44,14 +48,14 @@ IF (WIN32)
 	#add_subdirectory("sapi")
 	#add_subdirectory("nvda-synthDriver")
 	#add_subdirectory("wininst")
-else()
-	if(BUILD_SERVICE)
-		add_subdirectory("service")
-	endif(BUILD_SERVICE)
-
-	if(BUILD_SPEECHDISPATCHER_MODULE)
-		add_subdirectory("sd_module")
-	endif(BUILD_SPEECHDISPATCHER_MODULE)
 endif()
+
+if(BUILD_SERVICE)
+	add_subdirectory("service")
+endif(BUILD_SERVICE)
+
+if(BUILD_SPEECHDISPATCHER_MODULE)
+	add_subdirectory("sd_module")
+endif(BUILD_SPEECHDISPATCHER_MODULE)
 
 pass_through_cpack_vars()

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -14,8 +14,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+pkg_check_modules(DBUS REQUIRED dbus)
+
 add_executable("RHVoice-client" "${CMAKE_CURRENT_SOURCE_DIR}/rhvoice-client.c")
-target_link_libraries("RHVoice-client" "RHVoice_core")
+target_include_directories("RHVoice-client" PRIVATE "${DBUS_INCLUDE_DIRS}")
+target_link_libraries("RHVoice-client" PRIVATE "RHVoice_core" "${DBUS_LIBRARIES}")
 harden("RHVoice-client")
 add_sanitizers("RHVoice-client")
 target_compile_definitions("RHVoice-client" PRIVATE "-DVERSION=\"${VERSION}\"")

--- a/src/sd_module/CMakeLists.txt
+++ b/src/sd_module/CMakeLists.txt
@@ -14,10 +14,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+pkg_check_modules(SPEECHD REQUIRED speech-dispatcher)
+
 file(GLOB_RECURSE SRCFILES "${CMAKE_CURRENT_SOURCE_DIR}/*.c" "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 add_executable(sd_rhvoice "${SRCFILES}")
-target_include_directories(sd_rhvoice PRIVATE "${INCLUDE_DIR}" "${HTS_LABELS_KIT_INCLUDES}")
-target_link_libraries(sd_rhvoice "RHVoice_core" "RHVoice_audio" pthread)
+target_include_directories(sd_rhvoice PRIVATE "${INCLUDE_DIR}" "${HTS_LABELS_KIT_INCLUDES}" "${SPEECHD_INCLUDE_DIRS}")
+target_link_libraries(sd_rhvoice "RHVoice_core" "RHVoice_audio" "${SPEECHD_LIBRARIES}" pthread)
 harden(sd_rhvoice)
 add_sanitizers(sd_rhvoice)
 


### PR DESCRIPTION
Instead they are now built depending solely on the BUILD_ options, but these options are initialized depending on the presence of components' dependencies. So a user can override these options, if he really needs so (it would fail, if the dependencies are not met, but he can provide them too via the cache vars set by pkg-config).