### PR TITLE
Android 11 compatibility

### DIFF
--- a/src/android/RHVoice-core/build.gradle
+++ b/src/android/RHVoice-core/build.gradle
@@ -15,6 +15,11 @@ task addConfigFile(type: Copy) {
 android {
     compileSdkVersion myCompileSdkVersion
 
+compileOptions {
+sourceCompatibility JavaVersion.VERSION_1_8
+  targetCompatibility JavaVersion.VERSION_1_8
+}
+
     defaultConfig {
         minSdkVersion myMinSdkVersion
         targetSdkVersion myTargetSdkVersion
@@ -80,6 +85,8 @@ dependencies {
     implementation 'androidx.preference:preference:1.1.1'
     implementation 'org.conscrypt:conscrypt-android:2.5.2'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
+    implementation "androidx.documentfile:documentfile:1.0.1"
+    implementation 'com.google.guava:guava:30.1.1-android'
 }
 
 preBuild.dependsOn addConfigFile

--- a/src/android/RHVoice-core/build.gradle
+++ b/src/android/RHVoice-core/build.gradle
@@ -4,14 +4,6 @@ ext.major_version=1
 ext.minor_version=5
 ext.revision_number=12
 
-ext.myConfigFile=file("../../../config/RHVoice.conf")
-ext.myExtraCoreAssetsDir=new File(new File(new File(buildDir,"data"),"core"),"assets")
-
-task addConfigFile(type: Copy) {
-    from myConfigFile
-    into myExtraCoreAssetsDir
-}
-
 android {
     compileSdkVersion myCompileSdkVersion
 
@@ -35,10 +27,6 @@ sourceCompatibility JavaVersion.VERSION_1_8
             }
         }
     }
-
-    sourceSets.main {
-    assets.srcDir myExtraCoreAssetsDir
-}
 
 if(rootProject.signRelease||rootProject.signDebug) {
     signingConfigs {
@@ -88,5 +76,3 @@ dependencies {
     implementation "androidx.documentfile:documentfile:1.0.1"
     implementation 'com.google.guava:guava:30.1.1-android'
 }
-
-preBuild.dependsOn addConfigFile

--- a/src/android/RHVoice-core/build.gradle
+++ b/src/android/RHVoice-core/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 ext.major_version=1
-ext.minor_version=4
-ext.revision_number=2
+ext.minor_version=5
+ext.revision_number=12
 
 ext.myConfigFile=file("../../../config/RHVoice.conf")
 ext.myExtraCoreAssetsDir=new File(new File(new File(buildDir,"data"),"core"),"assets")
@@ -74,12 +74,12 @@ buildTypes {
 
 dependencies {
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'androidx.recyclerview:recyclerview:1.2.0'
-    implementation 'androidx.work:work-runtime:2.5.0'
-    implementation 'com.takisoft.preferencex:preferencex:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation 'androidx.recyclerview:recyclerview:1.2.1'
+    implementation 'androidx.work:work-runtime:2.7.0'
+    implementation 'androidx.preference:preference:1.1.1'
     implementation 'org.conscrypt:conscrypt-android:2.5.2'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
 }
 
 preBuild.dependsOn addConfigFile

--- a/src/android/RHVoice-core/src/main/AndroidManifest.xml
+++ b/src/android/RHVoice-core/src/main/AndroidManifest.xml
@@ -62,5 +62,7 @@ android:networkSecurityConfig="@xml/netsec">
         <category android:name="android.intent.category.DEFAULT"/>
       </intent-filter>
     </activity>
+    <service android:name=".ImportConfigService"
+             android:exported="false"/>
   </application>
 </manifest>

--- a/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/Config.java
+++ b/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/Config.java
@@ -55,4 +55,9 @@ public final class Config
     {
         return new File(getDictsRootDir(ctx), langName);
     }
+
+    public static File getConfigFile(Context ctx)
+    {
+        return new File(getDir(ctx), CONFIG_FILE_NAME);
+    }
 }

--- a/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/Config.java
+++ b/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/Config.java
@@ -30,36 +30,6 @@ public final class Config
     private static final String TAG="RHVoiceConfig";
     private static final String CONFIG_FILE_NAME="RHVoice.conf";
 
-    private static void unpackFile(Context context,String inPath,File outFile) throws IOException
-    {
-        InputStream inStream=null;
-        OutputStream outStream=null;
-        try
-            {
-                inStream=context.getAssets().open(inPath);
-                outStream=new FileOutputStream(outFile);
-                byte[] buf=new byte[8092];
-                int count=0;
-                while((count=inStream.read(buf))>0)
-                    outStream.write(buf,0,count);
-            }
-        finally
-            {
-                if(outStream!=null)
-                    outStream.close();
-                if(inStream!=null)
-                    inStream.close();
-            }
-    }
-
-    private static void unpackConfigFile(Context context,File configDir) throws IOException
-    {
-        File configFile=new File(configDir,CONFIG_FILE_NAME);
-        if(configFile.exists())
-            return;
-        unpackFile(context,CONFIG_FILE_NAME,configFile);
-    }
-
     public static File getDir(Context context)
     {
         if(BuildConfig.DEBUG)
@@ -73,13 +43,6 @@ public final class Config
             }
         if(BuildConfig.DEBUG)
             Log.d(TAG,"The path to the private external storage directory is "+dir.getAbsolutePath());
-        try
-            {
-                unpackConfigFile(context,dir);
-            }
-        catch(IOException e)
-            {
-            }
         return dir;
     }
 

--- a/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/Config.java
+++ b/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/Config.java
@@ -82,4 +82,14 @@ public final class Config
             }
         return dir;
     }
+
+    public static File getDictsRootDir(Context ctx)
+    {
+        return new File(getDir(ctx), "dicts");
+    }
+
+    public static File getLangDictsDir(Context ctx, String langName)
+    {
+        return new File(getDictsRootDir(ctx), langName);
+    }
 }

--- a/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/DataPack.java
+++ b/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/DataPack.java
@@ -325,7 +325,7 @@ public abstract class DataPack
         return getInstallationDir(context,getVersionCode()).exists();
 }
 
-    protected final void copyBytes(InputStream in,OutputStream out,IDataSyncCallback callback) throws IOException
+    protected static final void copyBytes(InputStream in,OutputStream out,IDataSyncCallback callback) throws IOException
     {
         byte[] buf=new byte[8092];
         int numBytes;

--- a/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/ImportConfigService.java
+++ b/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/ImportConfigService.java
@@ -1,0 +1,66 @@
+/* Copyright (C) 2021  Olga Yakovleva <olga@rhvoice.org> */
+
+/* This program is free software: you can redistribute it and/or modify */
+/* it under the terms of the GNU Lesser General Public License as published by */
+/* the Free Software Foundation, either version 2.1 of the License, or */
+/* (at your option) any later version. */
+
+/* This program is distributed in the hope that it will be useful, */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
+/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the */
+/* GNU Lesser General Public License for more details. */
+
+/* You should have received a copy of the GNU Lesser General Public License */
+/* along with this program.  If not, see <https://www.gnu.org/licenses/>. */
+
+
+package com.github.olga_yakovleva.rhvoice.android;
+
+import android.app.IntentService;
+import android.content.Intent;
+import androidx.documentfile.provider.DocumentFile;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.FileOutputStream;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+
+public final class ImportConfigService extends IntentService
+{
+    public static final String ACTION_IMPORT_USER_DICT="org.rhvoice.action.IMPORT_USER_DICT";
+    public static final String EXTRA_LANGUAGE="language";
+
+    public ImportConfigService()
+    {
+        super("RHVoice.ImportConfigService");
+    }
+
+    private void importUserDict(Intent intent)
+    {
+        final DocumentFile inFile=DocumentFile.fromSingleUri(this, intent.getData());
+        final String lang=intent.getStringExtra(EXTRA_LANGUAGE);
+        final File outDir=Config.getLangDictsDir(this, lang);
+        outDir.mkdirs();
+        final File outFile=new File(outDir, inFile.getName());
+        try(InputStream in=getContentResolver().openInputStream(intent.getData());
+            FileOutputStream out=new FileOutputStream(outFile)) {
+            DataPack.copyBytes(in, out, null);
+        } catch (IOException e) {
+            outFile.delete();
+            return;
+        }
+        LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent(RHVoiceService.ACTION_CONFIG_CHANGE));
+    }
+
+    @Override
+    protected void onHandleIntent(Intent intent)
+    {
+        switch (intent.getAction()) {
+        case ACTION_IMPORT_USER_DICT:
+            importUserDict(intent);
+            break;
+        default:
+            break;
+        }
+    }
+}

--- a/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/RHVoiceService.java
+++ b/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/RHVoiceService.java
@@ -58,6 +58,7 @@ public final class RHVoiceService extends TextToSpeechService
     private static final Pattern DEFAULT_VOICE_NAME_PATTERN=Pattern.compile("^([a-z]{3})-default$");
 
     public static final String ACTION_CHECK_DATA="com.github.olga_yakovleva.rhvoice.android.action.service_check_data";
+    public static final String ACTION_CONFIG_CHANGE="org.rhvoice.action.CONFIG_CHANGE";
     private final BroadcastReceiver dataStateReceiver=new BroadcastReceiver()
         {
             @Override
@@ -70,7 +71,7 @@ public final class RHVoiceService extends TextToSpeechService
                 boolean changed=!paths.equals(oldPaths);
                 if(BuildConfig.DEBUG)
                     Log.v(TAG,"Paths changed: "+changed);
-                if(changed)
+                if(changed || ACTION_CONFIG_CHANGE.equals(intent.getAction()))
                     initialize();
 }
         };
@@ -490,7 +491,9 @@ public final class RHVoiceService extends TextToSpeechService
         handler=new Handler();
         paths=Data.getPaths(this);
         Data.scheduleSync(this,false);
-        LocalBroadcastManager.getInstance(this).registerReceiver(dataStateReceiver,new IntentFilter(ACTION_CHECK_DATA));
+        IntentFilter filter=new IntentFilter(ACTION_CHECK_DATA);
+        filter.addAction(ACTION_CONFIG_CHANGE);
+        LocalBroadcastManager.getInstance(this).registerReceiver(dataStateReceiver,filter);
         registerPackageReceiver();
         initialize();
         super.onCreate();

--- a/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/RemoveUserDictDialogFragment.java
+++ b/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/RemoveUserDictDialogFragment.java
@@ -1,0 +1,72 @@
+/* Copyright (C) 2021  Olga Yakovleva <olga@rhvoice.org> */
+
+/* This program is free software: you can redistribute it and/or modify */
+/* it under the terms of the GNU Lesser General Public License as published by */
+/* the Free Software Foundation, either version 2.1 of the License, or */
+/* (at your option) any later version. */
+
+/* This program is distributed in the hope that it will be useful, */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
+/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the */
+/* GNU Lesser General Public License for more details. */
+
+/* You should have received a copy of the GNU Lesser General Public License */
+/* along with this program.  If not, see <https://www.gnu.org/licenses/>. */
+
+package com.github.olga_yakovleva.rhvoice.android;
+
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.os.Bundle;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatDialogFragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+import com.google.common.collect.FluentIterable;
+import java.io.File;
+import java.util.Arrays;
+
+public final class RemoveUserDictDialogFragment extends AppCompatDialogFragment
+{
+    private static final String ARG_LANGUAGE="language";
+    private String languageName;
+    private String[] userDicts;
+
+    public void onCreate(Bundle state)
+    {
+        super.onCreate(state);
+        Bundle args=getArguments();
+        languageName=args.getString(ARG_LANGUAGE);
+        userDicts=FluentIterable.from(Config.getLangDictsDir(requireActivity(), languageName).listFiles()).filter(f-> f.isFile()).transform(f-> f.getName()).toArray(String.class);
+        Arrays.sort(userDicts);
+}
+
+    @Override
+    public Dialog onCreateDialog(Bundle state)
+    {
+        AlertDialog.Builder builder=new AlertDialog.Builder(getActivity());
+        builder.setTitle(R.string.remove);
+        builder.setItems(userDicts, this::onDictSelected);
+        return builder.create();
+    }
+
+    private void onDictSelected(DialogInterface dialog, int index)
+    {
+        final File dictFile=new File(Config.getLangDictsDir(getActivity(), languageName), userDicts[index]);
+        dictFile.delete();
+        LocalBroadcastManager.getInstance(getActivity()).sendBroadcast(new Intent(RHVoiceService.ACTION_CONFIG_CHANGE));
+    }
+
+    public static void show(FragmentActivity activity, String langName)
+    {
+        if(langName==null)
+            return;
+        Bundle args=new Bundle();
+        args.putString(ARG_LANGUAGE,langName);
+        RemoveUserDictDialogFragment frag=new RemoveUserDictDialogFragment();
+        frag.setArguments(args);
+        frag.show(activity.getSupportFragmentManager(), "remove_user_dict");
+}
+}

--- a/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/RemoveUserDictDialogFragment.java
+++ b/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/RemoveUserDictDialogFragment.java
@@ -39,7 +39,11 @@ public final class RemoveUserDictDialogFragment extends AppCompatDialogFragment
         super.onCreate(state);
         Bundle args=getArguments();
         languageName=args.getString(ARG_LANGUAGE);
-        userDicts=FluentIterable.from(Config.getLangDictsDir(requireActivity(), languageName).listFiles()).filter(f-> f.isFile()).transform(f-> f.getName()).toArray(String.class);
+        final File[] dictFiles=Config.getLangDictsDir(requireActivity(), languageName).listFiles();
+        if(dictFiles==null)
+            userDicts=new String[]{};
+        else
+            userDicts=FluentIterable.from(dictFiles).filter(f-> f.isFile()).transform(f-> f.getName()).toArray(String.class);
         Arrays.sort(userDicts);
 }
 

--- a/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/SettingsFragment.java
+++ b/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/SettingsFragment.java
@@ -30,9 +30,8 @@ import android.text.InputFilter;
 import android.text.InputType;
 import com.github.olga_yakovleva.rhvoice.LanguageInfo;
 import com.github.olga_yakovleva.rhvoice.VoiceInfo;
-import com.takisoft.preferencex.AutoSummaryEditTextPreference;
-import com.takisoft.preferencex.PreferenceCategory;
-import com.takisoft.preferencex.PreferenceFragmentCompat;
+import androidx.preference.PreferenceCategory;
+import androidx.preference.PreferenceFragmentCompat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -113,7 +112,7 @@ import java.util.TreeMap;
         }
 
         @Override
-        public void onCreatePreferencesFix(Bundle state,String rootKey)
+        public void onCreatePreferences(Bundle state,String rootKey)
         {
             setPreferencesFromResource(R.xml.settings,null);
             List<VoiceInfo> voices=Data.getVoices(getActivity());

--- a/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/SettingsFragment.java
+++ b/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/SettingsFragment.java
@@ -115,11 +115,11 @@ import java.util.TreeMap;
         public void onCreatePreferences(Bundle state,String rootKey)
         {
             setPreferencesFromResource(R.xml.settings,null);
+            findPreference("version").setSummary(BuildConfig.VERSION_NAME);
             List<VoiceInfo> voices=Data.getVoices(getActivity());
             if(voices.isEmpty())
                 return;
             Map<String,List<VoiceInfo>> voiceGroups=groupVoicesByLanguage(voices);
-            findPreference("version").setSummary(BuildConfig.VERSION_NAME);
             PreferenceCategory cat=new PreferenceCategory(getPreferenceManager().getContext());
             cat.setOrder(100);
             cat.setKey("languages");

--- a/src/android/RHVoice-core/src/main/res/values-eo/strings.xml
+++ b/src/android/RHVoice-core/src/main/res/values-eo/strings.xml
@@ -30,4 +30,5 @@
   <string name="user_dicts">Uzantvortaroj</string>
   <string name="add">Aldoni</string>
   <string name="remove">Forigi</string>
+  <string name="config_file">Agorda dosiero</string>
 </resources>

--- a/src/android/RHVoice-core/src/main/res/values-eo/strings.xml
+++ b/src/android/RHVoice-core/src/main/res/values-eo/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <resources>
   <string name="default_voice_title">Implicita voĉo</string>
   <string name="default_voice_dialog_title">Elekti voĉon</string>
@@ -27,4 +27,7 @@
   <string name="decrease">Malpliigi</string>
   <string name="reset">Reagordi</string>
   <string name="version">Versio</string>
+  <string name="user_dicts">Uzantvortaroj</string>
+  <string name="add">Aldoni</string>
+  <string name="remove">Forigi</string>
 </resources>

--- a/src/android/RHVoice-core/src/main/res/values-ky/strings.xml
+++ b/src/android/RHVoice-core/src/main/res/values-ky/strings.xml
@@ -1,31 +1,34 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <resources>
   <!-- Translated by Iskender Sultanaliev <bishkek-fenomen@mail.ru> -->
-    <string name="default_voice_title">Баштапкы үн</string>
-    <string name="default_voice_dialog_title">Үн тандоо</string>
-    <string name="detect_language_title">Тилди аныктоо</string>
-    <string name="detect_language_desc">Тилди автоматтык түрдө алмаштыруу</string>
-    <string name="speech_volume">Үндүн катуулугу</string>
-    <string name="speech_rate">Үндүн ылдамдыгы</string>
-    <string name="pseudo_english_title">Англис сөздөр</string>
-    <string name="pseudo_english_desc">Англис сөздөрүн туура окууга аракеттенүү</string>
-    <string name="settings">Түзөтүүлөр</string>
-    <string name="wifi_only_title">Wi-Fi боюнча гана</string>
-    <string name="wifi_only_desc">Wi-Fi боюнча гана үндү жүктөө</string>
-    <string name="speech_quality">Сүйлөө сапаты</string>
-    <string-array name="quality_labels">
-      <item>Ылдамдыктын жакшыртылган мүмкүнчүлүгү</item>
-      <item>Стандарттык сапат</item>
-      <item>Мүмкүн болгон эң жакшы сапат</item>
-    </string-array>
-    <string name="languages">Тилдер</string>
-    <string name="voice_remove_question">Бул үндү өчүрүү керекпи?</string>
-    <string name="install">Орнотуу</string>
-    <string name="uninstall">Өчүрүү</string>
+  <string name="default_voice_title">Баштапкы үн</string>
+  <string name="default_voice_dialog_title">Үн тандоо</string>
+  <string name="detect_language_title">Тилди аныктоо</string>
+  <string name="detect_language_desc">Тилди автоматтык түрдө алмаштыруу</string>
+  <string name="speech_volume">Үндүн катуулугу</string>
+  <string name="speech_rate">Үндүн ылдамдыгы</string>
+  <string name="pseudo_english_title">Англис сөздөр</string>
+  <string name="pseudo_english_desc">Англис сөздөрүн туура окууга аракеттенүү</string>
+  <string name="settings">Түзөтүүлөр</string>
+  <string name="wifi_only_title">Wi-Fi боюнча гана</string>
+  <string name="wifi_only_desc">Wi-Fi боюнча гана үндү жүктөө</string>
+  <string name="speech_quality">Сүйлөө сапаты</string>
+  <string-array name="quality_labels">
+    <item>Ылдамдыктын жакшыртылган мүмкүнчүлүгү</item>
+    <item>Стандарттык сапат</item>
+    <item>Мүмкүн болгон эң жакшы сапат</item>
+  </string-array>
+  <string name="languages">Тилдер</string>
+  <string name="voice_remove_question">Бул үндү өчүрүү керекпи?</string>
+  <string name="install">Орнотуу</string>
+  <string name="uninstall">Өчүрүү</string>
   <string name="play">Ойнотуу</string>
   <string name="stop">Токтотуу</string>
   <string name="increase">Чоңойтуу</string>
   <string name="decrease">Азайтуу</string>
   <string name="reset">Баштапкы калыбына келтирүү</string>
   <string name="version">Версия</string>
+  <string name="user_dicts">Колдонуучу сөздүктөр</string>
+  <string name="add">кошуу</string>
+  <string name="remove">Алып салуу</string>
 </resources>

--- a/src/android/RHVoice-core/src/main/res/values-ky/strings.xml
+++ b/src/android/RHVoice-core/src/main/res/values-ky/strings.xml
@@ -31,5 +31,5 @@
   <string name="user_dicts">Колдонуучу сөздүктөр</string>
   <string name="add">кошуу</string>
   <string name="remove">Алып салуу</string>
-  <string name="config_file">Тарам билэ</string>
+  <string name="config_file">Конфигурациялык файл</string>
 </resources>

--- a/src/android/RHVoice-core/src/main/res/values-ky/strings.xml
+++ b/src/android/RHVoice-core/src/main/res/values-ky/strings.xml
@@ -31,4 +31,5 @@
   <string name="user_dicts">Колдонуучу сөздүктөр</string>
   <string name="add">кошуу</string>
   <string name="remove">Алып салуу</string>
+  <string name="config_file">Тарам билэ</string>
 </resources>

--- a/src/android/RHVoice-core/src/main/res/values-mk/strings.xml
+++ b/src/android/RHVoice-core/src/main/res/values-mk/strings.xml
@@ -28,7 +28,7 @@
   <string name="reset">Ресетирај</string>
   <string name="version">Верзија</string>
   <string name="user_dicts">Кориснички речници</string>
-  <string name="add">Додадете</string>
+  <string name="add">Додади</string>
   <string name="remove">Отстрани</string>
   <string name="config_file">Конфигурациска датотека</string>
 </resources>

--- a/src/android/RHVoice-core/src/main/res/values-mk/strings.xml
+++ b/src/android/RHVoice-core/src/main/res/values-mk/strings.xml
@@ -30,4 +30,5 @@
   <string name="user_dicts">Кориснички речници</string>
   <string name="add">Додадете</string>
   <string name="remove">Отстрани</string>
+  <string name="config_file">Конфигурациска датотека</string>
 </resources>

--- a/src/android/RHVoice-core/src/main/res/values-mk/strings.xml
+++ b/src/android/RHVoice-core/src/main/res/values-mk/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <resources>
   <string name="default_voice_title">Претпочитан глас</string>
   <string name="default_voice_dialog_title">Изберете глас</string>
@@ -27,4 +27,7 @@
   <string name="decrease">Намали</string>
   <string name="reset">Ресетирај</string>
   <string name="version">Верзија</string>
+  <string name="user_dicts">Кориснички речници</string>
+  <string name="add">Додадете</string>
+  <string name="remove">Отстрани</string>
 </resources>

--- a/src/android/RHVoice-core/src/main/res/values-pt/strings.xml
+++ b/src/android/RHVoice-core/src/main/res/values-pt/strings.xml
@@ -30,6 +30,6 @@
   <string name="version">Versão</string>
   <string name="user_dicts">Dicionários do usuário</string>
   <string name="add">Adicionar</string>
-  <string name="remove">Retirar</string>
+  <string name="remove">Remover</string>
   <string name="config_file">Arquivo de configuração</string>
 </resources>

--- a/src/android/RHVoice-core/src/main/res/values-pt/strings.xml
+++ b/src/android/RHVoice-core/src/main/res/values-pt/strings.xml
@@ -31,4 +31,5 @@
   <string name="user_dicts">Dicionários do usuário</string>
   <string name="add">Adicionar</string>
   <string name="remove">Retirar</string>
+  <string name="config_file">Arquivo de configuração</string>
 </resources>

--- a/src/android/RHVoice-core/src/main/res/values-pt/strings.xml
+++ b/src/android/RHVoice-core/src/main/res/values-pt/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <resources>
   <!-- Translated by Cleverson Casarin Uliana -->
   <string name="default_voice_title">Voz padrão</string>
@@ -28,4 +28,7 @@
   <string name="decrease">Diminuir</string>
   <string name="reset">Restaurar</string>
   <string name="version">Versão</string>
+  <string name="user_dicts">Dicionários do usuário</string>
+  <string name="add">Adicionar</string>
+  <string name="remove">Retirar</string>
 </resources>

--- a/src/android/RHVoice-core/src/main/res/values-ru/strings.xml
+++ b/src/android/RHVoice-core/src/main/res/values-ru/strings.xml
@@ -1,31 +1,34 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <resources>
   <!-- Translated by Olga Yakovleva <yakovleva.o.v@gmail.com> -->
-    <string name="default_voice_title">Голос по умолчанию</string>
-    <string name="default_voice_dialog_title">Выберите голос</string>
-    <string name="detect_language_title">Определение языка</string>
-    <string name="detect_language_desc">Автоматическое переключение языка</string>
-    <string name="speech_volume">Громкость речи</string>
-    <string name="speech_rate">Скорость речи</string>
-    <string name="pseudo_english_title">Английские слова</string>
-    <string name="pseudo_english_desc">Стараться правильно читать английские слова</string>
-    <string name="settings">Настройки</string>
-    <string name="wifi_only_title">Только Wi-Fi</string>
-    <string name="wifi_only_desc">Загружать голоса только по Wi-Fi</string>
-    <string name="speech_quality">Качество речи</string>
-    <string-array name="quality_labels">
-      <item>Наилучшее возможное быстродействие</item>
-      <item>Стандартное качество</item>
-      <item>Наилучшее возможное качество</item>
-    </string-array>
-    <string name="languages">Языки</string>
-    <string name="voice_remove_question">Удалить этот голос?</string>
-    <string name="install">Установить</string>
-    <string name="uninstall">Удалить</string>
-    <string name="play">Воспроизвести</string>
-    <string name="stop">Остановить</string>
-    <string name="increase">Увеличить</string>
-    <string name="decrease">Уменьшить</string>
-    <string name="reset">Сброс</string>
-    <string name="version">Версия</string>
+  <string name="default_voice_title">Голос по умолчанию</string>
+  <string name="default_voice_dialog_title">Выберите голос</string>
+  <string name="detect_language_title">Определение языка</string>
+  <string name="detect_language_desc">Автоматическое переключение языка</string>
+  <string name="speech_volume">Громкость речи</string>
+  <string name="speech_rate">Скорость речи</string>
+  <string name="pseudo_english_title">Английские слова</string>
+  <string name="pseudo_english_desc">Стараться правильно читать английские слова</string>
+  <string name="settings">Настройки</string>
+  <string name="wifi_only_title">Только Wi-Fi</string>
+  <string name="wifi_only_desc">Загружать голоса только по Wi-Fi</string>
+  <string name="speech_quality">Качество речи</string>
+  <string-array name="quality_labels">
+    <item>Наилучшее возможное быстродействие</item>
+    <item>Стандартное качество</item>
+    <item>Наилучшее возможное качество</item>
+  </string-array>
+  <string name="languages">Языки</string>
+  <string name="voice_remove_question">Удалить этот голос?</string>
+  <string name="install">Установить</string>
+  <string name="uninstall">Удалить</string>
+  <string name="play">Воспроизвести</string>
+  <string name="stop">Остановить</string>
+  <string name="increase">Увеличить</string>
+  <string name="decrease">Уменьшить</string>
+  <string name="reset">Сброс</string>
+  <string name="version">Версия</string>
+  <string name="user_dicts">Пользовательские словари</string>
+  <string name="add">Добавить</string>
+  <string name="remove">Удалить</string>
 </resources>

--- a/src/android/RHVoice-core/src/main/res/values-ru/strings.xml
+++ b/src/android/RHVoice-core/src/main/res/values-ru/strings.xml
@@ -31,4 +31,5 @@
   <string name="user_dicts">Пользовательские словари</string>
   <string name="add">Добавить</string>
   <string name="remove">Удалить</string>
+  <string name="config_file">Конфигурационный файл</string>
 </resources>

--- a/src/android/RHVoice-core/src/main/res/values-uk/strings.xml
+++ b/src/android/RHVoice-core/src/main/res/values-uk/strings.xml
@@ -31,4 +31,5 @@
   <string name="user_dicts">Словники користувача</string>
   <string name="add">Додати</string>
   <string name="remove">Видалити</string>
+  <string name="config_file">Конфігураційний файл</string>
 </resources>

--- a/src/android/RHVoice-core/src/main/res/values-uk/strings.xml
+++ b/src/android/RHVoice-core/src/main/res/values-uk/strings.xml
@@ -1,31 +1,34 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <resources>
   <!-- Translated by Maksym Bilak <bmiv@ukr.net>, Volodymyr Pyrih <vp88.mobile@gmail.com> -->
-    <string name="default_voice_title">Основний голос</string>
-    <string name="default_voice_dialog_title">Оберіть голос</string>
-    <string name="detect_language_title">Визначення мови</string>
-    <string name="detect_language_desc">Автоматично перемикатися між мовами</string>
-    <string name="speech_volume">Гучність мовлення</string>
-    <string name="speech_rate">Швидкість мовлення</string>
-    <string name="pseudo_english_title">Англійські слова</string>
-    <string name="pseudo_english_desc">Намагатися правильно читати англійські слова</string>
-    <string name="settings">Налаштування</string>
-    <string name="wifi_only_title">Лише Wi-Fi</string>
-    <string name="wifi_only_desc">Завантажувати голоси лише через Wi-Fi</string>
-    <string name="speech_quality">Якість мовлення</string>
-    <string-array name="quality_labels">
-      <item>Найкраща можлива швидкодія</item>
-      <item>Стандартна якість</item>
-      <item>Найкраща можлива якість</item>
-    </string-array>
-    <string name="languages">Мови</string>
-    <string name="voice_remove_question">Вилучити цей голос?</string>
-    <string name="install">Встановити</string>
-    <string name="uninstall">Видалити</string>
+  <string name="default_voice_title">Основний голос</string>
+  <string name="default_voice_dialog_title">Оберіть голос</string>
+  <string name="detect_language_title">Визначення мови</string>
+  <string name="detect_language_desc">Автоматично перемикатися між мовами</string>
+  <string name="speech_volume">Гучність мовлення</string>
+  <string name="speech_rate">Швидкість мовлення</string>
+  <string name="pseudo_english_title">Англійські слова</string>
+  <string name="pseudo_english_desc">Намагатися правильно читати англійські слова</string>
+  <string name="settings">Налаштування</string>
+  <string name="wifi_only_title">Лише Wi-Fi</string>
+  <string name="wifi_only_desc">Завантажувати голоси лише через Wi-Fi</string>
+  <string name="speech_quality">Якість мовлення</string>
+  <string-array name="quality_labels">
+    <item>Найкраща можлива швидкодія</item>
+    <item>Стандартна якість</item>
+    <item>Найкраща можлива якість</item>
+  </string-array>
+  <string name="languages">Мови</string>
+  <string name="voice_remove_question">Вилучити цей голос?</string>
+  <string name="install">Встановити</string>
+  <string name="uninstall">Видалити</string>
   <string name="play">Відтворити</string>
   <string name="stop">Зупинити</string>
   <string name="increase">Збільшити</string>
   <string name="decrease">Зменшити</string>
   <string name="reset">Скинути</string>
   <string name="version">Версія</string>
+  <string name="user_dicts">Словники користувача</string>
+  <string name="add">Додати</string>
+  <string name="remove">Видалити</string>
 </resources>

--- a/src/android/RHVoice-core/src/main/res/values/strings.xml
+++ b/src/android/RHVoice-core/src/main/res/values/strings.xml
@@ -27,4 +27,7 @@
   <string name="decrease">Decrease</string>
   <string name="reset">Reset</string>
   <string name="version">Version</string>
+  <string name="user_dicts">User dictionaries</string>
+  <string name="add">Add</string>
+  <string name="remove">Remove</string>
 </resources>

--- a/src/android/RHVoice-core/src/main/res/values/strings.xml
+++ b/src/android/RHVoice-core/src/main/res/values/strings.xml
@@ -30,4 +30,5 @@
   <string name="user_dicts">User dictionaries</string>
   <string name="add">Add</string>
   <string name="remove">Remove</string>
+  <string name="config_file">Configuration file</string>
 </resources>

--- a/src/android/RHVoice-core/src/main/res/xml/settings.xml
+++ b/src/android/RHVoice-core/src/main/res/xml/settings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
 android:key="root">
     <CheckBoxPreference
         android:title="@string/wifi_only_title"
@@ -17,6 +18,13 @@ android:key="root">
         android:dialogTitle="@string/speech_quality"
         android:summary="%s"
         android:order="20"/>
+    <SwitchPreferenceCompat
+        android:title="@string/config_file"
+        android:key="config_file"
+        android:persistent="false"
+        android:defaultValue="false"
+        android:order="199"
+        app:isPreferenceVisible="false"/>
     <Preference
         android:key="version"
         android:persistent="false"

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -17,7 +17,7 @@ allprojects {
 
     ext.myMinSdkVersion=16
     ext.myCompileSdkVersion=31
-    ext.myTargetSdkVersion=29
+    ext.myTargetSdkVersion=30
 }
 
 if(hasProperty("RHVoice.signRelease")) {

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -2,7 +2,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 
     dependencies {
@@ -14,11 +13,10 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 
     ext.myMinSdkVersion=16
-    ext.myCompileSdkVersion=29
+    ext.myCompileSdkVersion=31
     ext.myTargetSdkVersion=29
 }
 


### PR DESCRIPTION
* The target version is set to Android 11 now. Google Play will not
 accept our updates without this change.
* It's now possible to import a configuration file and user
  dictionaries into the app through its own user interface. This new
  feature should work on any Android version since 4.4. Copy the files
  somewhere on the device, then use the new options to copy them into
  the app.
* Ukrainian and Esperanto translations need to be checked. If nobody
  comments on those, we'll have to publish with what Google Translate
  has suggested, which is already in the sources.
* This should fix #283.
