### PR TITLE
voice-building-utils correction and convert-audio to py3 migration.

### DIFF
--- a/src/scripts/general/voice-building-utils
+++ b/src/scripts/general/voice-building-utils
@@ -767,7 +767,10 @@ class f0_range_computer(f0_extracter):
 	def __call__(self,args):
 		raw_dir=os.path.join("data","raw")
 		data=list()
-		method=self.settings["guess_f0_method"]
+		if "guess_f0_method" in self.settings:
+			method=self.settings["guess_f0_method"]
+		else:
+			method=None
 		if (not isinstance(method,str)) or len(method)==0:
 			method="sptk_rapt"
 		for name in sorted(os.listdir(raw_dir)):

--- a/src/scripts/hts/data/Makefile.in
+++ b/src/scripts/hts/data/Makefile.in
@@ -114,7 +114,7 @@ features:
 			if [ $(USESTRAIGHT) -eq 0 ]; then \
 				# $(X2X) +sf $${raw} | $(PITCH) -H $(UPPERF0) -L $(LOWERF0) -p $(FRAMESHIFT) -s $${SAMPKHZ} -o 2 > lf0/$${base}.lf0; \
 				if [ $(GAMMA) -eq 0 ]; then \
-					env python2 scripts/convert-audio $${raw} | \
+					env python3 scripts/convert-audio $${raw} | \
 					$(FRAME) -l $(FRAMELEN) -p $(FRAMESHIFT) | \
 					$(WINDOW) -l $(FRAMELEN) -L $(FFTLEN) -w $(WINDOWTYPE) -n $(NORMALIZE) | \
 					$(MGCEP) -a $(FREQWARP) -m $(MGCORDER) -l $(FFTLEN) -e 1.0E-08 > mgc/$${base}.mgc; \

--- a/src/scripts/hts/data/scripts/convert-audio
+++ b/src/scripts/hts/data/scripts/convert-audio
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # -*- coding: utf-8; mode: Python; indent-tabs-mode: t -*-
 
 import sys
@@ -15,9 +15,9 @@ with open(os.path.join("..","training.cfg"),"r") as f:
 target_db=settings.get("volume",-20)
 target=10.0**(target_db/20.0)
 
-audio=numpy.fromfile(sys.argv[1],numpy.int32).astype(numpy.float)/(2**31)
+audio=numpy.fromfile(sys.argv[1],numpy.int32).astype(float)/(2**31)
 rms=numpy.sqrt(numpy.mean(audio*audio))
 ratio=target/rms
 audio*=ratio
 audio*=(2**15)
-audio.astype(numpy.float32).tofile(sys.stdout)
+sys.stdout.buffer.write(audio.astype(numpy.float32).tobytes())


### PR DESCRIPTION
- Convert-audio converted to py3.
- voice-building-utils: fixed no key guess_f0_method.
- makefile.in calls convert-audio with python3, not python2.