### PR TITLE
Partially parallel context clustering.

### DIFF
--- a/src/scripts/hts/scripts/Config.pm.in
+++ b/src/scripts/hts/scripts/Config.pm.in
@@ -258,6 +258,7 @@ $IFFTR        = '@IFFTR@';
 $MATLAB   = '@MATLAB@';
 $STRAIGHT = '@STRAIGHT@';
 
+$NUMPROC = 1;
 
 # Switch ================================
 $MKEMV = 1; # preparing environments


### PR DESCRIPTION
* Only each parameter type is clustered independently in this version, not each state, so it will only be able to take advantage of up to 4 cores.
* The Parallel::ForkManager Perl module is now required to run the training script.
* Change the value of the $NUMPROC variable in scripts/Config.pm to let the script run the clustering steps in parallel. See above, no sense in setting it to a value grater than 4.
* Remember that it will mean more memory usage, so be careful. If the training crashes, it's very likely your server ran out of memory executing those steps at the same time.
