### PR TITLE
Make RHVoice compatible with NVDA again

### DIFF
--- a/site_scons/RHVoicePackaging/nvda.py
+++ b/site_scons/RHVoicePackaging/nvda.py
@@ -34,7 +34,7 @@ class addon_packager(archiver):
 		if data_package:
 			self.set_string("lastTestedNVDAVersion", "2099.4.0")
 		else:
-			self.set_string("lastTestedNVDAVersion", "2021.1.0")
+			self.set_string("lastTestedNVDAVersion", "2022.1.0")
 
 	def build_manifest(self,lang=None):
 		if lang:


### PR DESCRIPTION
# background context
Today, in the alpha snapshots, as well as in the beta branch, NVDA compatibility api has changed, so this allow us to run RHVoice on the latest NVDA versions. 
There are no changes in the synthDriver core, which affect us.