### PR TITLE
Support new speech-dispatcher modules location

### DIFF
--- a/src/sd_module/CMakeLists.txt
+++ b/src/sd_module/CMakeLists.txt
@@ -23,7 +23,12 @@ target_link_libraries(sd_rhvoice "RHVoice_core" "RHVoice_audio" "${SPEECHD_LIBRA
 harden(sd_rhvoice)
 add_sanitizers(sd_rhvoice)
 
-set(SPEECH_DISPATCHER_MODULES_DIR "${CMAKE_INSTALL_PREFIX}/lib/speech-dispatcher-modules" CACHE PATH "Speech Dispatcher's module directory path")
+pkg_get_variable(modulebindir ${SPEECHD_MODULE_NAME} modulebindir)
+if (NOT modulebindir)
+	pkg_get_variable(libdir ${SPEECHD_MODULE_NAME} libdir)
+	set(modulebindir "${libdir}/speech-dispatcher-modules")
+endif()
+set(SPEECH_DISPATCHER_MODULES_DIR "${modulebindir}" CACHE PATH "Speech Dispatcher's module directory path")
 
 
 cpack_add_component(sd_module


### PR DESCRIPTION
Use pkgconfig to get the location to install speech-dispatcher modules, since speech-dispatcher-0.11 changed from installing them in `{libdir}/speech-dispatcher-modules` to `{libexec}/speech-dispatcher-modules`.

I do not have much experience with CMake, so it is possible that my approach is not optimal, but I tested building against speech-dispatcher-0.9.1 (which does not expose a `modulebindir` pkg-config variable) and speech-dispatcher-0.11.1 (which does) and the sd_rhvoice module was installed in the correct location in each case.

(Obsoletes #503.)