### PR TITLE
Voice building utils: fixed lpf making with latest scipy and python 3.10 on latest linux systems

### DIFF
--- a/src/scripts/general/voice-building-utils
+++ b/src/scripts/general/voice-building-utils
@@ -1280,7 +1280,10 @@ class lpf_maker(task):
 		filters=numpy.zeros((nf,nt),dtype=numpy.float32)
 		for j in range(nf):
 			cf=(j+1)*1000
-			filters[j]=firwin(nt,cf,window="hanning",nyq=nyq)
+			try:
+				filters[j]=firwin(nt,cf,window="hanning",nyq=nyq)
+			except:
+				filters[j]=firwin(nt,cf,window="hann",nyq=nyq)
 		with open(os.path.join(self.outdir,"lpf.pdf"),"wb") as fp:
 			counts.tofile(fp)
 			for i in range(ns):


### PR DESCRIPTION
This update fixes the situation, where the lpc making is not working on newer python 3.10 and newer systems, like ubuntu 22.04.01 Lts, i.e, anything which uses newer python, scipy and numpy.
I also took care of the backwards compatibility. Tested this on python 3.8 (OLD ONE) and 3.10 (NEW ONE).