### PR TITLE
Voice building utils: changes for new praat

### DIFF
--- a/src/scripts/general/import.praat
+++ b/src/scripts/general/import.praat
@@ -74,7 +74,7 @@ speech=Extract part... start end rectangular 1 no
 if invert!=0
 speech=Multiply: -1
 endif
-speech=Subtract mean
+Subtract mean
 if sample_rate!=src_sample_rate
 Resample: sample_rate, 70
 endif


### PR DESCRIPTION
From now on, when training voices, new praat can be used, along with the old one.
We can use praat from 6.0.xx to 6.3.