### PR TITLE
Compatibility with future NVDA stable version

### DIFF
--- a/site_scons/RHVoicePackaging/nvda.py
+++ b/site_scons/RHVoicePackaging/nvda.py
@@ -34,7 +34,7 @@ class addon_packager(archiver):
 		if data_package:
 			self.set_string("lastTestedNVDAVersion", "2099.4.0")
 		else:
-			self.set_string("lastTestedNVDAVersion", "2022.1.0")
+			self.set_string("lastTestedNVDAVersion", "2023.1.0")
 
 	def build_manifest(self,lang=None):
 		if lang:


### PR DESCRIPTION
Updated the compatibility information for the new NVDA version, as the beta 1 from NV acess is declared. We are doing this to ensure compatibility with the new future NVDA version.