### PR TITLE
Pitch_shift property in voice.params.

### DIFF
--- a/src/core/hts_engine_impl.cpp
+++ b/src/core/hts_engine_impl.cpp
@@ -32,6 +32,7 @@ namespace RHVoice
     quality(quality_none),
     int_key("key",200,50,500),
     emph_shift("emph_shift",0,-12,12),
+    base_pitch_shift("pitch_shift",0,-12,12),
     input(0),
     output(0),
     rate(1.0),
@@ -71,6 +72,7 @@ namespace RHVoice
     cfg2.register_setting(native_rate);
     cfg2.register_setting(int_key);
     cfg2.register_setting(emph_shift);
+    cfg2.register_setting(base_pitch_shift);
     cfg2.load(path::join(data_path,"voice.params"));
     if(int_key.is_set())
       pitch_editor.set_key(int_key);

--- a/src/include/core/hts_engine_impl.hpp
+++ b/src/include/core/hts_engine_impl.hpp
@@ -81,9 +81,10 @@ namespace RHVoice
     void set_input(hts_input& input_)
     {
       input=&input_;
+      pitch_shift=std::log(2.0)*base_pitch_shift/12.0;
       if(input->lbegin()!=input->lend())
         {
-          pitch_shift=std::log(input->lbegin()->get_pitch());
+          pitch_shift+=std::log(input->lbegin()->get_pitch());
           if(input->lbegin()->get_segment().get_relation().get_utterance().get_utt_type()=="e")
             pitch_shift+=std::log(2.0)*emph_shift/12.0;
         }
@@ -137,6 +138,7 @@ namespace RHVoice
     quality_t quality;
     numeric_property<unsigned int> int_key;
     numeric_property<double> emph_shift;
+    numeric_property<double> base_pitch_shift;
     std::unique_ptr<equalizer> eq;
 
     double get_emph_shift() const


### PR DESCRIPTION
If the developer wants the voice to have slightly higher or lower pitch by default. The value is in semitones.
