### PR TITLE
Another kind of simple language switching.

### DIFF
--- a/src/core/document.cpp
+++ b/src/core/document.cpp
@@ -383,6 +383,7 @@ namespace RHVoice
   std::unique_ptr<utterance> sentence::create_utterance(sentence_position pos) const
   {
     std::unique_ptr<utterance> u=new_utterance();
+    u->set_bilingual_enabled(parent->enable_bilingual);
     apply_speech_settings(*u);
     execute_commands(*u);
     u->get_language().tokenize(*u);

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -72,7 +72,8 @@ namespace RHVoice
     languages(p.get_language_paths(),path::join(config_path,"dicts"),*p.logger),
     voices(p.get_voice_paths(),languages,*p.logger),
     logger(p.logger),
-    prefer_primary_language("prefer_primary_language",true)
+    prefer_primary_language("prefer_primary_language",true),
+    enable_bilingual("enable_bilingual", true)
   {
     logger->log(tag,RHVoice_log_level_info,"creating a new engine");
     if(p.has_data_paths() && languages.empty())
@@ -83,6 +84,7 @@ namespace RHVoice
     text_settings.register_self(cfg);
     verbosity_settings.register_self(cfg);
     cfg.register_setting(prefer_primary_language);
+    cfg.register_setting(enable_bilingual);
     cfg.register_setting(quality);
     stream_settings.register_self(cfg);
     languages.register_settings(cfg);

--- a/src/core/language.cpp
+++ b/src/core/language.cpp
@@ -585,10 +585,18 @@ cfg.register_setting(lcfg.tok_sent);
     cfg.register_setting(lcfg.ph_flags);
     cfg.register_setting(lcfg.g2p_case);
     cfg.register_setting(lcfg.punct_eos);
+    cfg.register_setting(lcfg.bilingual);
     cfg.load(path::join(info_.get_data_path(),"language.conf"));
     try
       {
         english_phone_mapping_fst.reset(new fst(path::join(info_.get_data_path(),"english_phone_mapping.fst")));
+      }
+    catch(const io::open_error& e)
+      {
+      }
+    try
+      {
+        foreign_phone_mapping_fst.reset(new fst(path::join(info_.get_data_path(),"sl_phone_mapping.fst")));
       }
     catch(const io::open_error& e)
       {
@@ -631,6 +639,13 @@ cfg.register_setting(lcfg.tok_sent);
     try
       {
         accented_dtree.reset(new dtree(path::join(info_.get_data_path(),"accented.dt")));
+      }
+    catch(const io::open_error& e)
+      {
+      }
+    try
+      {
+        vocab_fst.reset(new fst(path::join(info_.get_data_path(), "vocab.fst")));
       }
     catch(const io::open_error& e)
       {
@@ -713,8 +728,56 @@ cfg.register_setting(lcfg.tok_sent);
             return token;
   }
 
+  item* language::try_as_foreign_token(utterance& u, const std::string& text, bool eos) const
+  {
+    if(lcfg.bilingual.is_set() && lcfg.tok_sent)
+      {
+	std::cerr << "Warning: need to implement language switching in sentence level tokenizers!";
+	return nullptr;
+      }
+    if(!u.get_bilingual_enabled())
+      return nullptr;
+    auto sl=get_second_language();
+    if(!sl)
+      return nullptr;
+    const auto is_not_punct=[] (utf8::uint32_t cp) {return !str::ispunct(cp);};
+    const utf8::iterator<std::string::const_iterator> token_start(text.begin(), text.begin(), text.end());
+    decltype(token_start) token_end(text.end(), text.begin(), text.end());
+		const auto word_start=std::find_if(token_start, token_end, is_not_punct);
+	if(word_start==token_end)
+	  return nullptr;
+	auto word_end=token_end;
+	do
+	  {
+	    --word_end;
+	    if(is_not_punct(*word_end))
+	      {
+		++word_end;
+		break;
+	      }
+	  }
+	while(word_end!=word_start);
+	std::vector<utf8::uint32_t> word;
+	std::transform(word_start, word_end, std::back_inserter(word), str::tolower);
+	if(is_in_vocabulary(word.begin(), word.end()))
+	  return nullptr;
+	if(!sl->is_in_vocabulary(word.begin(), word.end()))
+	  return nullptr;
+	auto& pt=sl->append_token(u, text, eos);
+	const std::string lang_name=sl->get_info().get_name();
+	for(auto& i: pt.as("TokStructure"))
+	  {
+	    const std::string& pos=i.get("pos").as<std::string>();
+	    if(pos=="word" || pos=="lseq")
+	      i.set("lang", lang_name);
+	  }
+	return &pt;
+  }
+
   item& language::append_token(utterance& u,const std::string& text, bool eos) const
   {
+    if(auto p=try_as_foreign_token(u, text, eos))
+      return *p;
     relation& token_rel=u.get_relation("Token",true);
     relation& tokstruct_rel=u.get_relation("TokStructure",true);
     item& parent_token=tokstruct_rel.append(token_rel.append());
@@ -976,9 +1039,12 @@ item& language::append_emoji(utterance& u,const std::string& text) const
 
   void language::decode(item& token) const
   {
+    if(auto sl=get_item_second_language(token))
+      return sl->decode(token);
     if(token.has_children())
       return;
     const std::string& token_pos=token.get("pos").as<std::string>();
+    const std::string& token_name=token.get("name").as<std::string>();
     if(token_pos=="ph")
       {
         token.append_child().set<std::string>("name", "_");
@@ -986,7 +1052,6 @@ item& language::append_emoji(utterance& u,const std::string& text) const
       }
     if(decode_as_english(token))
       return;
-    const std::string& token_name=token.get("name").as<std::string>();
     if(token_pos=="word")
       decode_as_word(token,token_name);
     else if(token_pos=="lseq")
@@ -1445,9 +1510,31 @@ void language::on_token_break(utterance& u) const
     return native_trans;
 }
 
+  std::vector<std::string> language::get_foreign_word_transcription(const item& word) const
+  {
+    auto fl=get_item_second_language(word.as("TokStructure").parent());
+    if(!fl)
+      return {};
+    if(foreign_phone_mapping_fst.get()==0)
+      throw std::runtime_error("No foreign phone mapping");
+    std::vector<std::string> fl_trans=fl->get_word_transcription(word);
+    std::vector<std::string> native_trans;
+    foreign_phone_mapping_fst->translate(fl_trans.begin(),fl_trans.end(),std::back_inserter(native_trans));
+    return native_trans;
+}
+
   void language::assign_pronunciation(item& word) const
   {
-    std::vector<std::string> transcription((get_info().use_pseudo_english&&word.has_feature("english"))?get_english_word_transcription(word):get_word_transcription(word));
+    std::vector<std::string> transcription=get_foreign_word_transcription(word);
+      if(word.has_feature("foreign"))
+      transcription=get_foreign_word_transcription(word);
+      if(transcription.empty())
+	{
+	  if(get_info().use_pseudo_english&&word.has_feature("english"))
+	    transcription=get_english_word_transcription(word);
+	  else
+	    transcription=get_word_transcription(word);
+	}
     str::tokenizer<str::is_equal_to> tokenizer("",str::is_equal_to('_'));
     std::string val("1");
     for(std::vector<std::string>::const_iterator it1=transcription.begin();it1!=transcription.end();++it1)
@@ -1659,7 +1746,36 @@ if(!pg2p_fst->translate(in_syms.begin(), in_syms.end(), std::back_inserter(out_s
 }
 }
 
+const language* language::get_second_language() const
+{
+  const auto name=lcfg.bilingual.get();
+  if(name.empty())
+    return nullptr;
+  if(!vocab_fst)
+    return nullptr;
+  if(!foreign_phone_mapping_fst)
+    return nullptr;
+    const auto& languages=get_info().get_all_languages();
+    auto lang_it=languages.find(name);
+    if(lang_it==languages.end())
+      return nullptr;
+    const auto& inst=lang_it->get_instance();
+    return &inst;
+}
 
+const language* language::get_item_second_language(const item& i) const
+{
+  if(!i.has_feature("lang"))
+    return nullptr;
+  auto sl=get_second_language();
+  if(!sl)
+    return nullptr;
+  const std::string& name=i.get("lang").as<std::string>();
+  if(sl->get_info().get_name()==name)
+    return sl;
+  else
+    return nullptr;
+}
 
   language_info::language_info(const std::string& name,const std::string& data_path_,const std::string& userdict_path_):
     use_pseudo_english("use_pseudo_english",true),

--- a/src/include/core/document.hpp
+++ b/src/include/core/document.hpp
@@ -321,6 +321,7 @@ namespace RHVoice
     speech_params speech_settings;
     verbosity_params verbosity_settings;
     quality_setting quality;
+    bool_property enable_bilingual{"enable_bilingual", true};
 
     explicit document(const std::shared_ptr<engine>& engine_ptr_,const voice_profile& profile_=voice_profile()):
       engine_ptr(engine_ptr_),
@@ -331,6 +332,7 @@ namespace RHVoice
     {
       verbosity_settings.default_to(engine_ptr->verbosity_settings);
       quality.default_to(engine_ptr->quality);
+      enable_bilingual.default_to(engine_ptr->enable_bilingual);
     }
 
     const engine& get_engine() const

--- a/src/include/core/engine.hpp
+++ b/src/include/core/engine.hpp
@@ -164,6 +164,7 @@ namespace RHVoice
     text_params text_settings;
     verbosity_params verbosity_settings;
     bool_property prefer_primary_language;
+    bool_property enable_bilingual;
     quality_setting quality;
     stream_params stream_settings;
   };

--- a/src/include/core/language.hpp
+++ b/src/include/core/language.hpp
@@ -225,6 +225,14 @@ namespace RHVoice
       return (emoji_fst.get()!=0);
 }
 
+    template<typename T> bool is_in_vocabulary(T first, T last) const
+    {
+      if(!vocab_fst)
+	return false;
+      std::vector<std::string> out;
+      return vocab_fst->translate(first, last, std::back_inserter(out));
+    }
+
     item& append_emoji(utterance& u,const std::string& text) const;
     void do_text_analysis(utterance& u) const;
     void do_pos_tagging(utterance& u) const;
@@ -271,6 +279,9 @@ namespace RHVoice
 
     virtual void assign_pronunciation(item& word) const;
 
+    const language* get_second_language() const;
+    const language* get_item_second_language(const item& i) const;
+
   private:
     language(const language&);
     language& operator=(const language&);
@@ -298,6 +309,7 @@ namespace RHVoice
     bool should_break_emoji(const item& word) const;
     bool decode_as_english(item& tok) const;
     std::vector<std::string> get_english_word_transcription(const item& word) const;
+    std::vector<std::string> get_foreign_word_transcription(const item& word) const;
 
     virtual void before_g2p(item& word) const
 {
@@ -313,6 +325,7 @@ namespace RHVoice
     void translate_emoji_sequence(item& token,const std::string& text) const;
     void set_user_phones(item& word) const;
     item& append_subtoken(item& parent_token, const std::string& name, const std::string& pos) const;
+    item* try_as_foreign_token(utterance& u, const std::string& text, bool eos) const;
 
     std::map<std::string,std::shared_ptr<feature_function> > feature_functions;
     const phoneme_set phonemes;
@@ -342,11 +355,14 @@ std::unique_ptr<fst> qst_fst;
       stringset_property ph_flags{"ph.flags"};
       bool_property g2p_case{"g2p.case", false};
       string_property punct_eos{"punct.eos"};
+      string_property bilingual{"bilingual"};
     };
 
     const fst spell_fst;
     const fst downcase_fst;
     std::unique_ptr<fst> pg2p_fst;
+    std::unique_ptr<fst> vocab_fst;
+    std::unique_ptr<fst> foreign_phone_mapping_fst;
     lang_config lcfg;
   };
 

--- a/src/include/core/utterance.hpp
+++ b/src/include/core/utterance.hpp
@@ -60,7 +60,8 @@ namespace RHVoice
     absolute_volume(0),
     relative_volume(1.0),
     utt_type("s"),
-    flags(0)
+    flags(0),
+    bilingual_enabled(true)
     {
     }
 
@@ -167,6 +168,16 @@ namespace RHVoice
         relative_volume=val;
     }
 
+    void set_bilingual_enabled(bool v)
+    {
+      bilingual_enabled=v;
+    }
+
+    bool get_bilingual_enabled()
+    {
+      return bilingual_enabled;
+    }
+
     relation& add_relation(const std::string& name);
     void remove_relation(const std::string& name);
 
@@ -220,6 +231,7 @@ namespace RHVoice
     double absolute_rate,relative_rate,absolute_pitch,relative_pitch,absolute_volume,relative_volume;
     std::string utt_type;
     int flags;
+    bool bilingual_enabled;
   };
 
   class utterance_function


### PR DESCRIPTION
This is meant for the case of a second language sharing most of the alphabet with the first language. The first language is the default. The second language is chosen only if a matching word is found with no clashes with the first language. The phoneme mapping is used the same way as for pseudo-English.
