### PR TITLE
Initialization reestimation improvement: let's use more iterations to load our models fully

### DIFF
--- a/src/scripts/hts/scripts/Config.pm.in
+++ b/src/scripts/hts/scripts/Config.pm.in
@@ -259,6 +259,7 @@ $MATLAB   = '@MATLAB@';
 $STRAIGHT = '@STRAIGHT@';
 
 $NUMPROC = 1;
+$NUMPHON = 20;
 $NUMCL = 2;
 
 # Switch ================================

--- a/src/scripts/hts/scripts/Training.pl
+++ b/src/scripts/hts/scripts/Training.pl
@@ -350,8 +350,8 @@ if ($IN_RE) {
 
          if ( grep( $_ eq $phone, keys %mdcp ) <= 0 ) {
             print "=============== $phone ================\n";
-            shell("$HInit -H $initmmf{'cmp'} -M $hinit{'cmp'} -I $lab -l $phone -o $phone $prtfile{'cmp'}");
-            shell("$HRest -H $initmmf{'cmp'} -M $hrest{'cmp'} -I $lab -l $phone -g $hrest{'dur'}/$phone $hinit{'cmp'}/$phone");
+            shell("$HInit -i $NUMPHON -H $initmmf{'cmp'} -M $hinit{'cmp'} -I $lab -l $phone -o $phone $prtfile{'cmp'}");
+            shell("$HRest -i $NUMPHON -H $initmmf{'cmp'} -M $hrest{'cmp'} -I $lab -l $phone -g $hrest{'dur'}/$phone $hinit{'cmp'}/$phone");
          }
       }
       close(LIST);


### PR DESCRIPTION
# background#
In the default setup we had partly initialized the phonemes.
Let's do this fully from now on.
## development approach
In the training.pl, lines 353, and 354, there is an -i parameter, with the variable. The variable has the reference in the config.pm.
From the config.pm, the initialization reestimation can be fine tuned.
$NUMPHON option accepts values from 20 to 100.
