### PR TITLE
Fix 'load error' on systems with incompatible locale

### DIFF
--- a/src/core/io.cpp
+++ b/src/core/io.cpp
@@ -52,6 +52,7 @@ namespace RHVoice
       #endif
       if(!stream.is_open())
         throw open_error(path);
+      stream.imbue(std::locale::classic());
     }
 
     void open_ofstream(std::ofstream& stream,const std::string& path,bool binary)
@@ -68,6 +69,7 @@ namespace RHVoice
       #endif
       if(!stream.is_open())
         throw open_error(path);
+      stream.imbue(std::locale::classic());
     }
   }
 }


### PR DESCRIPTION
Double values from data files could no be read on systems/programs that used a locale with different format for doubles. The solution is setting the locale of streams to the classic "C" locale.