### PR TITLE
Fix speech-dispatcher CMake rules

### DIFF
--- a/src/sd_module/CMakeLists.txt
+++ b/src/sd_module/CMakeLists.txt
@@ -16,9 +16,14 @@
 
 pkg_check_modules(SPEECHD REQUIRED speech-dispatcher)
 
+string(REPLACE "." ";" SPEECHD_VERSION_LIST ${SPEECHD_VERSION})
+list(GET SPEECHD_VERSION_LIST 0 SPD_MAJOR)
+list(GET SPEECHD_VERSION_LIST 1 SPD_MINOR)
+
 file(GLOB_RECURSE SRCFILES "${CMAKE_CURRENT_SOURCE_DIR}/*.c" "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 add_executable(sd_rhvoice "${SRCFILES}")
 target_include_directories(sd_rhvoice PRIVATE "${INCLUDE_DIR}" "${HTS_LABELS_KIT_INCLUDES}" "${SPEECHD_INCLUDE_DIRS}")
+target_compile_definitions(sd_rhvoice PRIVATE SPD_MAJOR=${SPD_MAJOR} SPD_MINOR=${SPD_MINOR})
 target_link_libraries(sd_rhvoice "RHVoice_core" "RHVoice_audio" "${SPEECHD_LIBRARIES}" pthread)
 harden(sd_rhvoice)
 add_sanitizers(sd_rhvoice)

--- a/src/sd_module/list_voices.cpp
+++ b/src/sd_module/list_voices.cpp
@@ -21,11 +21,11 @@
 
 namespace
 {
-#if ((SPD_MAJOR==0) && (SPD_MINOR<9))
+#if defined(SPD_MAJOR) && defined(SPD_MINOR) && SPD_MAJOR == 0 && SPD_MINOR < 9
   const char sep=' ';
 #else
   const char sep='\t';
-  #endif
+#endif
 }
 
 namespace RHVoice


### PR DESCRIPTION
Add missing SPD_MAJOR and SPD_MINOR declarations.

- [x] I license this contribution under Unlicense