### PR TITLE
NVDA driver compatibility with NVDA 2025.1 and older

### DIFF
--- a/site_scons/RHVoicePackaging/nvda.py
+++ b/site_scons/RHVoicePackaging/nvda.py
@@ -34,7 +34,7 @@ class addon_packager(archiver):
 		if data_package:
 			self.set_string("lastTestedNVDAVersion", "2099.4.0")
 		else:
-			self.set_string("lastTestedNVDAVersion", "2024.1.0")
+			self.set_string("lastTestedNVDAVersion", "2025.1.0")
 
 	def build_manifest(self,lang=None):
 		if lang:

--- a/src/nvda-addon/synthDriver/__init__.py
+++ b/src/nvda-addon/synthDriver/__init__.py
@@ -51,6 +51,7 @@ import addonHandler
 
 import addonAPIVersion
 api_version = addonAPIVersion.CURRENT
+import buildVersion
 
 module_dir = os.path.dirname(__file__)
 lib_path = os.path.join(module_dir, "RHVoice.dll")
@@ -189,9 +190,9 @@ class AudioPlayer:
             return None
         player = self.__players.get(self.__sample_rate, None)
         if player is None:
-            try:
+            if buildVersion.version_year < 2025:
              player = nvwave.WavePlayer(channels=1, samplesPerSec=self.__sample_rate, bitsPerSample=16, outputDevice=config.conf["speech"]["outputDevice"])
-            except:
+            else:
              player = nvwave.WavePlayer(channels=1, samplesPerSec=self.__sample_rate, bitsPerSample=16, outputDevice=config.conf["audio"]["outputDevice"])
             self.__players[self.__sample_rate] = player
         return player

--- a/src/nvda-addon/synthDriver/__init__.py
+++ b/src/nvda-addon/synthDriver/__init__.py
@@ -189,7 +189,10 @@ class AudioPlayer:
             return None
         player = self.__players.get(self.__sample_rate, None)
         if player is None:
-            player = nvwave.WavePlayer(channels=1, samplesPerSec=self.__sample_rate, bitsPerSample=16, outputDevice=config.conf["speech"]["outputDevice"])
+            try:
+             player = nvwave.WavePlayer(channels=1, samplesPerSec=self.__sample_rate, bitsPerSample=16, outputDevice=config.conf["speech"]["outputDevice"])
+            except:
+             player = nvwave.WavePlayer(channels=1, samplesPerSec=self.__sample_rate, bitsPerSample=16, outputDevice=config.conf["audio"]["outputDevice"])
             self.__players[self.__sample_rate] = player
         return player
 

--- a/src/nvda-addon/synthDriver/__init__.py
+++ b/src/nvda-addon/synthDriver/__init__.py
@@ -190,10 +190,7 @@ class AudioPlayer:
             return None
         player = self.__players.get(self.__sample_rate, None)
         if player is None:
-            if buildVersion.version_year < 2025:
-             player = nvwave.WavePlayer(channels=1, samplesPerSec=self.__sample_rate, bitsPerSample=16, outputDevice=config.conf["speech"]["outputDevice"])
-            else:
-             player = nvwave.WavePlayer(channels=1, samplesPerSec=self.__sample_rate, bitsPerSample=16, outputDevice=config.conf["audio"]["outputDevice"])
+            player = nvwave.WavePlayer(channels=1, samplesPerSec=self.__sample_rate, bitsPerSample=16, outputDevice=self.__synth.outputDeviceSection["outputDevice"])
             self.__players[self.__sample_rate] = player
         return player
 
@@ -503,6 +500,7 @@ class SynthDriver(SynthDriver):
     def __init__(self):
         self.__lib = load_tts_library()
         self.__cancel_flag = threading.Event()
+        self.outputDeviceSection = config.conf["speech"] if buildVersion.version_year < 2025 else config.conf["audio"]
         self.__player = AudioPlayer(self, self.__cancel_flag)
         self.__sample_rate_callback = SampleRateCallback(self.__lib, self.__player)
         self.__c_sample_rate_callback = RHVoice_callback_types.set_sample_rate(self.__sample_rate_callback)


### PR DESCRIPTION
# context
In the future NVDA 2025.1, audio devices in the NVDA user configuration will be stored as endpoint Ids instead of friendly names.
# development strategy:
Changed the audio device lookup and selection strategy. We are trying two approaches: one from the old stable NVDA, and one which will be introduced in 2025.1
So, in the synth driver, we are using the following statements:
            try:
             player = nvwave.WavePlayer(channels=1, samplesPerSec=self.__sample_rate, bitsPerSample=16, outputDevice=config.conf["speech"]["outputDevice"])
            except:
             player = nvwave.WavePlayer(channels=1, samplesPerSec=self.__sample_rate, bitsPerSample=16, outputDevice=config.conf["audio"]["outputDevice"])
So, from now on, the new key for the ouptput device is not located in speech, but in audio, and I am maintaining the backwards compatibility, as seen in the above try/except block.
# testing strategy:
This fix was tested on the current stable NVDA version, 2024.1.0, as well as on the latest alpha version, from which the NVDA 2025.1 release is developing
nvaccess/nvda#17547
