### PR TITLE
Bug fix: certain comma pauses in voices trough NVDA synth driver

### DIFF
--- a/src/nvda-addon/synthDriver/__init__.py
+++ b/src/nvda-addon/synthDriver/__init__.py
@@ -573,6 +573,9 @@ class SynthDriver(SynthDriver):
 
     def speak(self, speechSequence):
         conv = SsmlConverter(self, self.language)
+        for i in range(len(speechSequence)):
+            if isinstance(speechSequence[i], str):
+                speechSequence[i] = speechSequence[i].replace(" , ", ", ")
         text = conv.convertToXml(speechSequence)
         task = SpeakText(self.__lib, self.__tts_engine, text, self.__cancel_flag, self.__player)
         task.set_voice_profile(self.__profile)


### PR DESCRIPTION
Hi.

I use RHVoice as a main synthesizer in NVDA's creen reader and, for example, when reading e-mails using gmail webpage, spaces between commas are not stripped, which means that the comma pause is not interpreted by the voice.
And, many language modules have the phrase tree, which inserts pause breaks according to punctuation, but according to a unique symbol name in the tokenizer, and many languages don't use the sentence level tokenization to detect pauses in these occasions, in which there is a space before and after the comma.
This approach works for me, and the driver is still fast.

Cheers.