### PR TITLE
NVDA addon: NVDA addon version is splitted from the core

### DIFF
--- a/src/nvda-addon/SConscript
+++ b/src/nvda-addon/SConscript
@@ -22,10 +22,11 @@ Import(["env"])
 
 from RHVoicePackaging.nvda import addon_packager
 
+addon_version="1.16.401"
+
 synthDriver_dir=os.path.join("synthDrivers","RHVoice")
 curdir=Dir(".").srcnode()
-packager=addon_packager("RHVoice",Dir("..").Dir("packages").Dir("nvda"),env,"RHVoice","RHVoice","A speech synthesizer.",env["package_version"])
-packager.translate_string("description","ru",u"Синтезатор речи.")
+packager=addon_packager("RHVoice",Dir("..").Dir("packages").Dir("nvda"),env,"RHVoice","RHVoice","A speech synthesizer.",addon_version)
 packager.add(curdir.File("installTasks.py"))
 packager.add(curdir.Dir("synthDriver").File("__init__.py"),synthDriver_dir)
 packager.add(os.path.join("..","x86","lib","RHVoice.dll"),synthDriver_dir)


### PR DESCRIPTION
# Changes:
* removed the hardcoded russian manifest, it was the source of the failing add-on datastore checks.
* NVDA addon version is splitted from the RHVoice core version.