### PR TITLE
NVDA addon: version bump for the NVDA addon store, stable channel

### DIFF
--- a/src/nvda-addon/SConscript
+++ b/src/nvda-addon/SConscript
@@ -22,7 +22,7 @@ Import(["env"])
 
 from RHVoicePackaging.nvda import addon_packager
 
-addon_version="1.16.401"
+addon_version="1.16.402"
 
 synthDriver_dir=os.path.join("synthDrivers","RHVoice")
 curdir=Dir(".").srcnode()


### PR DESCRIPTION
## description
This is just a cosmetic change, which is needed for the NVDA addon store, in order to declare the addon available in the stable channel for the NVDA version 2025.1