### PR TITLE
Added: Android direct boot support

### DIFF
--- a/src/android/RHVoice-core/src/main/AndroidManifest.xml
+++ b/src/android/RHVoice-core/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
     <service
         android:label="@string/app_name"
         android:name=".RHVoiceService"
+        android:directBootAware="true"
         android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.TTS_SERVICE"/>

--- a/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/CheckTTSData.java
+++ b/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/CheckTTSData.java
@@ -1,3 +1,5 @@
+/* Copyright (C) 2025  Darko Milosevic <daremc86@gmail.com> */
+
 /* Copyright (C) 2013, 2014, 2016, 2019  Olga Yakovleva <yakovleva.o.v@gmail.com> */
 
 /* This program is free software: you can redistribute it and/or modify */
@@ -18,6 +20,7 @@ package com.github.olga_yakovleva.rhvoice.android;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.content.Context;
 import android.os.Bundle;
 import android.speech.tts.TextToSpeech;
 
@@ -31,6 +34,7 @@ import android.util.Log;
 
 public final class CheckTTSData extends Activity {
     private static final String TAG = "RHVoiceCheckDataActivity";
+    private Context storageContext;
     private DataManager dm;
     private ArrayList<String> installedLanguages = new ArrayList<String>();
     private ArrayList<String> notInstalledLanguages = new ArrayList<String>();
@@ -42,7 +46,7 @@ public final class CheckTTSData extends Activity {
             boolean installed = false;
             boolean notInstalled = false;
             for (VoicePack voice : accent.getVoices()) {
-                if (voice.getEnabled(this) && voice.isUpToDate(this))
+                if (voice.getEnabled(storageContext) && voice.isUpToDate(storageContext))
                     installed = true;
                 else
                     notInstalled = true;
@@ -56,12 +60,13 @@ public final class CheckTTSData extends Activity {
             if (notInstalled)
                 notInstalledLanguages.add(tag);
         }
-        dm.scheduleSync(this, false);
+        dm.scheduleSync(storageContext, false);
     }
 
     @Override
     protected void onCreate(Bundle state) {
         super.onCreate(state);
+        storageContext = MyApplication.getStorageContext();
         dm = Repository.get().createDataManager();
         if (BuildConfig.DEBUG)
             Log.v(TAG, "checking data");

--- a/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/DataPack.java
+++ b/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/DataPack.java
@@ -1,3 +1,5 @@
+/* Copyright (C) 2025  Darko Milosevic <daremc86@gmail.com> */
+
 /* Copyright (C) 2017, 2018, 2019, 2021  Olga Yakovleva <olga@rhvoice.org> */
 
 /* This program is free software: you can redistribute it and/or modify */
@@ -65,6 +67,7 @@ import java.util.zip.ZipInputStream;
 
 public abstract class DataPack {
     private static final String TAG = "RHVoiceDataPack";
+    private static Context storageContext = MyApplication.getStorageContext();
 
     private String getWorkName() {
         StringBuilder b = new StringBuilder();
@@ -144,6 +147,7 @@ public abstract class DataPack {
     }
 
     public final PackageInfo getPackageInfo(Context context) {
+        context = storageContext;
         PackageManager pm = context.getPackageManager();
         try {
             PackageInfo pi = pm.getPackageInfo(getPackageName(), 0);
@@ -156,6 +160,7 @@ public abstract class DataPack {
     }
 
     public final String getLink(Context context) {
+        context = storageContext;
         return getRes().dataUrl;
     }
 
@@ -164,22 +169,27 @@ public abstract class DataPack {
     }
 
     protected final File getDataDir(Context context) {
+        context = storageContext;
         return context.getDir("data", 0).getAbsoluteFile();
     }
 
     protected final File getTempDir(Context context) {
+        context = storageContext;
         return context.getDir("tmp-" + getType() + "-" + getId(), 0);
     }
 
     private File getDownloadsDir(Context context) {
+        context = storageContext;
         return context.getDir("downloads-" + getType() + "-" + getId(), 0);
     }
 
     private File getDownloadFile(Context context) {
+        context = storageContext;
         return new File(getDownloadsDir(context), getDownloadFileName());
     }
 
     private File getTempDownloadFile(Context context) {
+        context = storageContext;
         return new File(getDownloadsDir(context), getDownloadFileName() + ".tmp");
     }
 
@@ -210,6 +220,7 @@ public abstract class DataPack {
     }
 
     protected final boolean safeDelete(Context context, File file) {
+        context = storageContext;
         if (!file.exists())
             return true;
         if (!file.isDirectory())
@@ -246,11 +257,13 @@ public abstract class DataPack {
     }
 
     public final File getInstallationDir(Context context, int versionCode) {
+        context = storageContext;
         File dataDir = getDataDir(context);
         return new File(dataDir, String.format("%s.%d", getPackageName(), versionCode));
     }
 
     public final boolean isUpToDate(Context context) {
+        context = storageContext;
         return getInstallationDir(context, getVersionCode()).exists();
     }
 
@@ -271,6 +284,7 @@ public abstract class DataPack {
     }
 
     private InputStream openResource(Context context) throws IOException {
+        context = storageContext;
         if (BuildConfig.DEBUG)
             Log.v(TAG, "Trying to open resources in a package");
         PackageInfo pi = getPackageInfo(context);
@@ -354,6 +368,7 @@ public abstract class DataPack {
     }
 
     private InputStream openLink(Context context, IDataSyncCallback callback) throws IOException {
+        context = storageContext;
         if (BuildConfig.DEBUG)
             Log.v(TAG, "Trying to open the link");
         File file = getDownloadFile(context);
@@ -365,6 +380,7 @@ public abstract class DataPack {
     }
 
     private void downloadFile(Context context, IDataSyncCallback callback) throws IOException {
+        context = storageContext;
         checkIfStopped(callback);
         String link = getLink(context);
         if (BuildConfig.DEBUG)
@@ -444,6 +460,7 @@ public abstract class DataPack {
     }
 
     private InputStream open(Context context, IDataSyncCallback callback) throws IOException {
+        context = storageContext;
         if (BuildConfig.DEBUG)
             Log.v(TAG, "Opening");
         try {
@@ -472,6 +489,7 @@ public abstract class DataPack {
     }
 
     public boolean install(Context context, IDataSyncCallback callback) {
+        context = storageContext;
         if (isUpToDate(context))
             return true;
         if (BuildConfig.DEBUG)
@@ -555,6 +573,7 @@ public abstract class DataPack {
     }
 
     private void cleanup(Context context, int versionCode) {
+        context = storageContext;
         delete(getDownloadsDir(context));
         String pkgName = getPackageName();
         File instDir = (versionCode > 0) ? getInstallationDir(context, versionCode) : null;
@@ -572,6 +591,7 @@ public abstract class DataPack {
     }
 
     protected static final SharedPreferences getPrefs(Context context) {
+        context = storageContext;
         return PreferenceManager.getDefaultSharedPreferences(context);
     }
 
@@ -580,6 +600,7 @@ public abstract class DataPack {
     }
 
     public final String getPath(Context context) {
+        context = storageContext;
         File dir = getInstallationDir(context, getVersionCode());
         if (dir.exists())
             return dir.getPath();
@@ -601,6 +622,7 @@ public abstract class DataPack {
     }
 
     public final boolean isInstalled(Context context) {
+        context = storageContext;
         return (getPath(context) != null);
     }
 
@@ -610,6 +632,7 @@ public abstract class DataPack {
     }
 
     public void uninstall(Context context, IDataSyncCallback callback) {
+        context = storageContext;
         if (BuildConfig.DEBUG)
             Log.v(TAG, "Removing " + getType() + " " + getName());
         cleanup(context, 0);
@@ -621,6 +644,7 @@ public abstract class DataPack {
     public abstract boolean getEnabled(Context context);
 
     public boolean sync(Context context, IDataSyncCallback callback) {
+        context = storageContext;
         if (getEnabled(context)) {
             if (!isUpToDate(context)) {
                 boolean installed = install(context, callback);
@@ -645,10 +669,12 @@ public abstract class DataPack {
     }
 
     public long getSyncFlag(Context context) {
+        context = storageContext;
         return getSyncFlag(context, false);
     }
 
     public long getSyncFlag(Context context, boolean checkPkg) {
+        context = storageContext;
         if (!getEnabled(context)) {
             if (isInstalled(context))
                 return SyncFlags.LOCAL;
@@ -663,6 +689,7 @@ public abstract class DataPack {
     }
 
     public boolean canBeInstalledFromPackage(Context context) {
+        context = storageContext;
         PackageInfo pi = getPackageInfo(context);
         if (pi != null && pi.versionCode == getVersionCode())
             return true;
@@ -687,6 +714,7 @@ public abstract class DataPack {
     }
 
     public static NetworkType getNetworkTypeSetting(Context context) {
+        context = storageContext;
         boolean wifiOnly = getPrefs(context).getBoolean("wifi_only", false);
         return wifiOnly ? NetworkType.UNMETERED : NetworkType.CONNECTED;
     }
@@ -698,6 +726,7 @@ public abstract class DataPack {
 
     @MainThread
     public final void scheduleSync(Context context, boolean replace) {
+        context = storageContext;
         long flag = getSyncFlag(context);
         if (flag == 0)
             return;
@@ -714,6 +743,7 @@ public abstract class DataPack {
     }
 
     protected String readTextFile(Context context, String fileName) {
+        context = storageContext;
         String dirPath = getPath(context);
         if (dirPath == null) {
             return null;
@@ -738,6 +768,7 @@ public abstract class DataPack {
     }
 
     public Spanned getAttribution(Context context) {
+        context = storageContext;
         String html = readTextFile(context, "attrib.html");
         if (html == null) {
             return null;
@@ -748,6 +779,7 @@ public abstract class DataPack {
     public abstract String getTestMessage();
 
     public final Version getInstalledVersion(Context ctx) {
+        ctx = storageContext;
         final String path = getPath(ctx);
         if (path == null)
             return null;

--- a/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/MigrationWorker.java
+++ b/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/MigrationWorker.java
@@ -1,0 +1,96 @@
+/* Copyright (C) 2025  Darko Milosevic <daremc86@gmail.com> */
+
+/* This program is free software: you can redistribute it and/or modify */
+/* it under the terms of the GNU Lesser General Public License as published by */
+/* the Free Software Foundation, either version 3 of the License, or */
+/* (at your option) any later version. */
+
+/* This program is distributed in the hope that it will be useful, */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
+/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the */
+/* GNU Lesser General Public License for more details. */
+
+/* You should have received a copy of the GNU Lesser General Public License */
+/* along with this program.  If not, see <https://www.gnu.org/licenses/>. */
+
+package com.github.olga_yakovleva.rhvoice.android;
+
+import android.content.Context;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
+import androidx.work.ExistingWorkPolicy;
+
+import android.os.Build;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public final class MigrationWorker extends Worker {
+    private static final String TAG = "RHVoice.MigrationWorker";
+
+    public MigrationWorker(@NonNull Context context, @NonNull WorkerParameters params) {
+        super(context, params);
+    }
+
+    @Override
+    public Result doWork() {
+        Context deCtx = MyApplication.getStorageContext();
+        Context ceCtx = getApplicationContext();
+
+
+        migrateDir("app_data", new File(ceCtx.getDataDir(), "app_data"), new File(deCtx.getDataDir(), "app_data"));
+        migrateDir("app_packages", new File(ceCtx.getDataDir(), "app_packages"), new File(deCtx.getDataDir(), "app_packages"));
+        migrateDir("cache", new File(ceCtx.getDataDir(), "cache"), new File(deCtx.getDataDir(), "cache"));
+        migrateDir("code_cache", new File(ceCtx.getDataDir(), "code_cache"), new File(deCtx.getDataDir(), "code_cache"));
+        migrateDir("files", new File(ceCtx.getDataDir(), "files"), new File(deCtx.getDataDir(), "files"));
+        migrateDir("shared_prefs", new File(ceCtx.getDataDir(), "shared_prefs"), new File(deCtx.getDataDir(), "shared_prefs"));
+        migrateDir("databases", new File(ceCtx.getDataDir(), "databases"), new File(deCtx.getDataDir(), "databases"));
+        migrateDir("no_backup", new File(ceCtx.getNoBackupFilesDir().getPath()), new File(deCtx.getNoBackupFilesDir().getPath()));
+
+        return Result.success();
+    }
+
+    private boolean copyFile(File src, File dst) {
+        try (InputStream in = new FileInputStream(src);
+            OutputStream out = new FileOutputStream(dst)) {
+            byte[] buffer = new byte[4096];
+            int length;
+            while ((length = in.read(buffer)) > 0) {
+                out.write(buffer, 0, length);
+            }
+            return true;
+        } catch (Exception e) {
+            Log.w(TAG, "Failed to copy file: " + src.getName(), e);
+            return false;
+        }
+    }
+
+    private void migrateDir(String name, File srcDir, File dstDir) {
+        if (!srcDir.exists()) return;
+        if (!dstDir.exists()) dstDir.mkdirs();
+
+        File[] files = srcDir.listFiles();
+        if (files == null) return;
+
+        for (File srcFile : files) {
+            File dstFile = new File(dstDir, srcFile.getName());
+            if (dstFile.exists()) continue;
+
+            boolean success = copyFile(srcFile, dstFile);
+            if (!success) {
+                if (BuildConfig.DEBUG)
+                    Log.w(TAG, "Failed to move " + name + ": " + srcFile.getName());
+            } else {
+                srcFile.delete();
+                if (BuildConfig.DEBUG)
+                    Log.v(TAG, "Moved " + srcFile.getAbsolutePath() + " to " + dstFile.getAbsolutePath());
+            }
+        }
+    }
+}

--- a/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/MyApplication.java
+++ b/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/MyApplication.java
@@ -1,3 +1,5 @@
+/* Copyright (C) 2025  Darko Milosevic <daremc86@gmail.com> */
+
 /* Copyright (C) 2018, 2021  Olga Yakovleva <olga@rhvoice.org> */
 
 /* This program is free software: you can redistribute it and/or modify */
@@ -16,6 +18,9 @@
 package com.github.olga_yakovleva.rhvoice.android;
 
 import androidx.multidex.MultiDexApplication;
+import android.content.Context;
+import android.os.Build;
+
 
 import android.util.Log;
 
@@ -31,10 +36,18 @@ import org.conscrypt.Conscrypt;
 
 public final class MyApplication extends MultiDexApplication {
     private static final String TAG = "RHVoice.MyApplication";
+    private static Context storageContext;
 
     @Override
     public void onCreate() {
         super.onCreate();
+        Context appContext = getApplicationContext();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            MyApplication.storageContext = appContext.createDeviceProtectedStorageContext();
+        }
+        else {
+            MyApplication.storageContext = appContext;
+        }
         DynamicColors.applyToActivitiesIfAvailable(this);
         try {
             Provider provider = Conscrypt.newProvider();
@@ -49,5 +62,8 @@ public final class MyApplication extends MultiDexApplication {
                 Log.e(TAG, "Error", e);
         }
         Repository.initialize(this);
+    }
+    public static Context getStorageContext() {
+        return MyApplication.storageContext;
     }
 }

--- a/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/PackageClient.java
+++ b/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/PackageClient.java
@@ -1,3 +1,5 @@
+/* Copyright (C) 2025  Darko Milosevic <daremc86@gmail.com> */
+
 /* Copyright (C) 2021  Olga Yakovleva <olga@rhvoice.org> */
 
 /* This program is free software: you can redistribute it and/or modify */
@@ -21,7 +23,9 @@ import android.content.Context;
 import java.io.File;
 
 final class PackageClient {
+    private static Context storageContext = MyApplication.getStorageContext();
     public static final String getPath(Context context) {
+        context = storageContext;
         File dir = context.getDir("packages", 0);
         if (!dir.isDirectory()) {
             dir.mkdirs();

--- a/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/Repository.java
+++ b/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/Repository.java
@@ -1,3 +1,5 @@
+/* Copyright (C) 2025  Darko Milosevic <daremc86@gmail.com> */
+
 /* Copyright (C) 2021, 2022  Olga Yakovleva <olga@rhvoice.org> */
 
 /* This program is free software: you can redistribute it and/or modify */
@@ -70,6 +72,7 @@ final class Repository {
 
     @MainThread
     private Repository(Context context) {
+        context = MyApplication.getStorageContext();
         this.context = context.getApplicationContext();
         try {
             {
@@ -92,6 +95,7 @@ final class Repository {
 
     @MainThread
     public static void initialize(Context context) {
+        context = MyApplication.getStorageContext();
         if (instance != null)
             throw new IllegalStateException();
         instance = new Repository(context);

--- a/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/SettingsListFragment.java
+++ b/src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/SettingsListFragment.java
@@ -1,3 +1,5 @@
+/* Copyright (C) 2025  Darko Milosevic <daremc86@gmail.com> */
+
 /* Copyright (C) 2013, 2014, 2016, 2017, 2018, 2019  Olga Yakovleva <yakovleva.o.v@gmail.com> */
 
 /* This program is free software: you can redistribute it and/or modify */
@@ -47,6 +49,7 @@ import java.util.regex.Pattern;
 
 public final class SettingsListFragment extends PreferenceFragmentCompat implements SharedPreferences.OnSharedPreferenceChangeListener {
     private static final String TAG = "RHVoiceSettingsActivity";
+    private static Context storageContext;
     public static final String NAME = "settingslist";
     public static final String ARG_LANGUAGE_KEY = "language_key";
     private static final Pattern RE_LANG_KEY = Pattern.compile("^language\\.([a-z]{3})$");
@@ -123,6 +126,10 @@ public final class SettingsListFragment extends PreferenceFragmentCompat impleme
 
     @Override
     public void onCreatePreferences(Bundle state, String rootKey) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            getPreferenceManager().setStorageDeviceProtected();
+        }
+        storageContext = MyApplication.getStorageContext();
         setPreferencesFromResource(R.xml.settings, null);
         findPreference("version").setSummary(BuildConfig.VERSION_NAME);
         if (openConfigFile != null) {
@@ -134,7 +141,7 @@ public final class SettingsListFragment extends PreferenceFragmentCompat impleme
         PreferenceCategory cat = null;
         final DataManager dm = Repository.get().createDataManager();
         for (LanguagePack lp : dm.iterLanguages()) {
-            final List<VoicePack> voices = lp.iterVoices().filter(v -> v.getEnabled(requireContext()) && v.isInstalled(requireContext())).toList();
+            final List<VoicePack> voices = lp.iterVoices().filter(v -> v.getEnabled(storageContext) && v.isInstalled(storageContext)).toList();
             if (voices.isEmpty())
                 continue;
             if (cat == null) {


### PR DESCRIPTION
# On branch Android_Direct_Boot
Changes to be committed:
- 	modified:   src/android/RHVoice-core/src/main/AndroidManifest.xml
- 	modified:   src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/CheckTTSData.java
- 	modified:   src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/DataPack.java
- 	modified:   src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/MainActivity.java
- 	new file:   src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/MigrationWorker.java
- 	modified:   src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/MyApplication.java
- 	modified:   src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/PackageClient.java
- 	modified:   src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/RHVoiceService.java
- 	modified:   src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/Repository.java
- 	modified:   src/android/RHVoice-core/src/main/java/com/github/olga_yakovleva/rhvoice/android/SettingsListFragment.java

# Changes

- Added routine to decide to use between user credential storage and device protected storage depends of Android version if >= 7
- Modifyed classes for checking data, downloading and installing packages, repository management to use device protected storage
- Modifyed AndroidManifest.xml to declare RHVoiceService to work in direct boot by adding android:directBootAware="true"
- Added MIgrationWorker class to copy previously installed voices when updating from the previous version of RHVoice to version with direct boot support

# Building

This code was building using OpenJDK 17 and gradle

- # Testing
- 
This code has been tested on several devices, including:
- Android 12
- Android 14
- Android 15
- Android 5.1
