### PR TITLE
Patch version bump

### DIFF
--- a/data/SConscript
+++ b/data/SConscript
@@ -12,7 +12,7 @@ import RHVoiceInfoParser
 Import("env")
 local_env=env.Clone()
 
-nvda_addon_build_number=".11"
+nvda_addon_build_number=".12"
 
 def list_files(dir):
 	files=[]
@@ -33,7 +33,7 @@ lang_files=dict()
 lang_ver_ids=dict()
 
 msi_build_number=".2"
-exe_build_number=".21"
+exe_build_number=".22"
 
 for dir_name in ["languages","voices"]:
 	type=dir_name[:-1]


### PR DESCRIPTION
# background 
Because of the fact, that new features arrived in core, notably time attribute for the break tag in Ssml, which is important for screen readers, the patch version number is increased:
So, for example: version number changes from 4.7.1027.11 to 4.7.1028.12 for NVDA, and from 21 to 22 for the sapi packages.
# development approach
Changed the sconscript in the data directory.
# testing strategy
Tested that the compilation works and that the generated packages bear new version numbers.

