### PR TITLE
This PR registers a handler for the SSML <lang> element so that SSML documents containing <lang> are parsed instead of being silently ignored or rejected.

### DIFF
--- a/src/include/core/document.hpp
+++ b/src/include/core/document.hpp
@@ -713,6 +713,8 @@ namespace RHVoice
     parser.add_element_handler(break_handler);
     ssml::phoneme_handler<char_type> phoneme_handler;
     parser.add_element_handler(phoneme_handler);
+    ssml::lang_handler<char_type> lang_handler;
+    parser.add_element_handler(lang_handler);
     parser.parse(text_start,text_end,*doc_ptr);
     return doc_ptr;
   }

--- a/src/include/core/ssml.hpp
+++ b/src/include/core/ssml.hpp
@@ -87,6 +87,22 @@ namespace RHVoice
     };
 
     template<typename ch>
+    class lang_handler: public language_tracking_element_handler<ch>
+    {
+    public:
+      lang_handler():
+      language_tracking_element_handler<ch>("lang")
+    {
+    }
+
+    private:
+      bool do_enter(xml::handler_args<ch>& args)
+      {
+        return ((args.node->parent())&&(args.node->parent()->type()==rapidxml::node_element));
+      }
+    };
+
+    template<typename ch>
     class s_handler: public language_tracking_element_handler<ch>
     {
     public:


### PR DESCRIPTION
## Motivation
Some SSML inputs include <lang> elements. Currently, when such input is passed to RHVoice, parsing may fail or result in no synthesized output. By registering <lang> as a recognized SSML element, these cases no longer cause RHVoice to be silent.
### What this change does:
- Adds ssml::lang_handler, derived from language_tracking_element_handler
- Registers the handler in the document parser
- Ensures <lang> is only processed when used as a proper XML element
What this change does not do:
- Does not implement language switching or voice selection
- Does not change synthesis behavior
- Does not introduce new SSML semantics

Before the following SSML could result in no output:
```
<speak>
  <lang xml:lang="en-US">
    Hello world
  </lang>
</speak>
```
### Scope
- Parsing-only change
- Backward compatible
- No API or behavioral changes